### PR TITLE
Mesh Overlap Fix

### DIFF
--- a/GraffitiGala/Assets/Scenes/NetworkingScene.unity
+++ b/GraffitiGala/Assets/Scenes/NetworkingScene.unity
@@ -3249,7 +3249,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95e80520e184e4b47b9bcdd84b5b8f9c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  buildType: 1
+  buildType: 2
 --- !u!4 &1259247656
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Fixed a small bug where the mesh would show two overlapping segments at the beginning of a brush stroke with the new spray paint texture.